### PR TITLE
feat(job components): core collab tabs and UI

### DIFF
--- a/packages/db/migrations/202409210000__job_req_notes_and_files.sql
+++ b/packages/db/migrations/202409210000__job_req_notes_and_files.sql
@@ -1,0 +1,164 @@
+-- Helper functions for job requisition access
+CREATE OR REPLACE FUNCTION public.fn_is_job_collaborator(job_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.job_requisition_collaborators c
+    WHERE c.job_id = job_uuid
+      AND c.user_id = user_uuid
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_is_job_creator(job_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.job_requisitions r
+    WHERE r.id = job_uuid
+      AND r.user_id = user_uuid
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_collab_role(job_uuid uuid, user_uuid uuid)
+RETURNS text
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    CASE
+      WHEN r.user_id = user_uuid THEN 'editor'
+      ELSE c.role
+    END
+  FROM public.job_requisitions r
+  LEFT JOIN public.job_requisition_collaborators c
+    ON c.job_id = r.id AND c.user_id = user_uuid
+  WHERE r.id = job_uuid;
+$$;
+
+-- Extend job_requisition_notes to link candidates and add supporting indexes
+DO $$
+BEGIN
+  IF to_regclass('public.job_requisition_notes') IS NOT NULL THEN
+    ALTER TABLE public.job_requisition_notes
+      ADD COLUMN IF NOT EXISTS candidate_id uuid REFERENCES public.candidates(id) ON DELETE SET NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_notes_job ON public.job_requisition_notes(job_id);
+    CREATE INDEX IF NOT EXISTS idx_notes_candidate ON public.job_requisition_notes(candidate_id);
+
+    ALTER TABLE public.job_requisition_notes ENABLE ROW LEVEL SECURITY;
+
+    CREATE POLICY job_requisition_notes_read ON public.job_requisition_notes
+      FOR SELECT
+      USING (public.fn_is_job_collaborator(job_id, auth.uid()));
+
+    CREATE POLICY job_requisition_notes_insert ON public.job_requisition_notes
+      FOR INSERT
+      WITH CHECK (public.fn_collab_role(job_id, auth.uid()) IN ('commenter','editor'));
+
+    CREATE POLICY job_requisition_notes_update ON public.job_requisition_notes
+      FOR UPDATE
+      USING (public.fn_collab_role(job_id, auth.uid()) = 'editor')
+      WITH CHECK (public.fn_collab_role(job_id, auth.uid()) = 'editor');
+  END IF;
+END
+$$;
+
+-- Activity indexes and policies
+DO $$
+BEGIN
+  IF to_regclass('public.job_requisition_activity') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_activity_job_created ON public.job_requisition_activity(job_id, created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_activity_job_type ON public.job_requisition_activity(job_id, type);
+
+    ALTER TABLE public.job_requisition_activity ENABLE ROW LEVEL SECURITY;
+
+    CREATE POLICY job_requisition_activity_read ON public.job_requisition_activity
+      FOR SELECT
+      USING (public.fn_is_job_collaborator(job_id, auth.uid()));
+
+    CREATE POLICY job_requisition_activity_insert ON public.job_requisition_activity
+      FOR INSERT
+      WITH CHECK (public.fn_collab_role(job_id, auth.uid()) IN ('commenter','editor'));
+  END IF;
+END
+$$;
+
+-- Collaborators index and policies
+DO $$
+BEGIN
+  IF to_regclass('public.job_requisition_collaborators') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_collab_job ON public.job_requisition_collaborators(job_id);
+
+    ALTER TABLE public.job_requisition_collaborators ENABLE ROW LEVEL SECURITY;
+
+    CREATE POLICY job_requisition_collaborators_read ON public.job_requisition_collaborators
+      FOR SELECT
+      USING (public.fn_is_job_collaborator(job_id, auth.uid()));
+
+    CREATE POLICY job_requisition_collaborators_manage ON public.job_requisition_collaborators
+      FOR ALL
+      USING (
+        public.fn_collab_role(job_id, auth.uid()) = 'editor'
+        OR public.fn_is_job_creator(job_id, auth.uid())
+      )
+      WITH CHECK (
+        public.fn_collab_role(job_id, auth.uid()) = 'editor'
+        OR public.fn_is_job_creator(job_id, auth.uid())
+      );
+  END IF;
+END
+$$;
+
+-- Candidate files table and policies
+CREATE TABLE IF NOT EXISTS public.candidate_files (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  candidate_id uuid REFERENCES public.candidates(id) ON DELETE CASCADE,
+  job_id uuid REFERENCES public.job_requisitions(id) ON DELETE CASCADE,
+  uploaded_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  filename text,
+  url text,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.candidate_files ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY candidate_files_read ON public.candidate_files
+  FOR SELECT
+  USING (public.fn_is_job_collaborator(job_id, auth.uid()));
+
+CREATE POLICY candidate_files_insert ON public.candidate_files
+  FOR INSERT
+  WITH CHECK (public.fn_collab_role(job_id, auth.uid()) IN ('commenter','editor'));
+
+CREATE POLICY candidate_files_update ON public.candidate_files
+  FOR UPDATE
+  USING (public.fn_collab_role(job_id, auth.uid()) = 'editor')
+  WITH CHECK (public.fn_collab_role(job_id, auth.uid()) = 'editor');
+
+CREATE POLICY candidate_files_delete ON public.candidate_files
+  FOR DELETE
+  USING (public.fn_collab_role(job_id, auth.uid()) = 'editor');
+
+-- Uniform status column for job_requisitions
+ALTER TABLE public.job_requisitions
+  ADD COLUMN IF NOT EXISTS status text
+    CHECK (status IN ('draft','open','on_hold','filled','archived'))
+    DEFAULT 'draft';
+
+-- Validation queries
+-- \d+ public.job_requisition_notes
+-- SELECT to_regclass('public.idx_notes_candidate');
+-- SELECT to_regclass('public.idx_activity_job_created');
+-- SELECT to_regclass('public.idx_collab_job');
+-- SELECT to_regclass('public.idx_activity_job_type');
+-- SELECT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='candidate_files');
+

--- a/packages/web/src/components/billing/PremiumFeatureLockModal.tsx
+++ b/packages/web/src/components/billing/PremiumFeatureLockModal.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface Props {
+  featureName: string;
+  onClose: () => void;
+}
+
+const PremiumFeatureLockModal: React.FC<Props> = ({ featureName, onClose }) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="relative w-full max-w-sm rounded bg-white p-6 text-center shadow-lg">
+        <button
+          onClick={onClose}
+          className="absolute right-2 top-2 text-gray-500"
+          aria-label="Close"
+        >
+          &times;
+        </button>
+        <div className="mb-4 text-4xl">🔒</div>
+        <h2 className="mb-2 text-xl font-semibold">
+          Unlock {featureName} with Pro or Team
+        </h2>
+        <p className="mb-4 text-gray-600">
+          Upgrade your plan to access this premium feature.
+        </p>
+        <div className="flex justify-center gap-4">
+          <a
+            href="/billing"
+            className="rounded bg-blue-600 px-4 py-2 text-white"
+          >
+            Billing
+          </a>
+          <a
+            href="/pricing"
+            className="rounded border border-gray-300 px-4 py-2 text-gray-700"
+          >
+            Pricing
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PremiumFeatureLockModal;

--- a/packages/web/src/components/common/FilterBar.tsx
+++ b/packages/web/src/components/common/FilterBar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface FilterBarProps {
+  filters: string[];
+  active: string[];
+  onToggle: (filter: string) => void;
+}
+
+const FilterBar: React.FC<FilterBarProps> = ({ filters, active, onToggle }) => {
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {filters.map((f) => {
+        const selected = active.includes(f);
+        return (
+          <button
+            key={f}
+            onClick={() => onToggle(f)}
+            className={`px-3 py-1 rounded-full text-sm border ${
+              selected
+                ? 'bg-blue-50 text-blue-700 border-blue-200'
+                : 'bg-gray-50 text-gray-600 border-gray-200'
+            }`}
+          >
+            {f}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default FilterBar;

--- a/packages/web/src/components/job/ActivityFeed.tsx
+++ b/packages/web/src/components/job/ActivityFeed.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface ActivityItem {
+  id: string;
+  text: string;
+  time: string;
+}
+
+const mock: ActivityItem[] = [
+  { id: '1', text: 'Alice updated the description', time: '2h ago' },
+  { id: '2', text: 'Bob commented on the job', time: '1h ago' },
+];
+
+export default function ActivityFeed() {
+  return (
+    <ul className="space-y-4">
+      {mock.map((a) => (
+        <li key={a.id} className="bg-white border border-gray-200 rounded-lg p-4">
+          <p className="text-sm text-gray-700">{a.text}</p>
+          <p className="text-xs text-gray-500 mt-1">{a.time}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/web/src/components/job/CandidateCommentsDrawer.tsx
+++ b/packages/web/src/components/job/CandidateCommentsDrawer.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import MentionInput from './MentionInput';
+
+interface Props {
+  candidateName: string;
+  onClose: () => void;
+}
+
+export default function CandidateCommentsDrawer({ candidateName, onClose }: Props) {
+  const [comments, setComments] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const add = () => {
+    if (!input.trim()) return;
+    setComments([...comments, input.trim()]);
+    setInput('');
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end">
+      <div className="w-80 h-full bg-white border-l border-gray-200 p-4 overflow-y-auto">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Comments for {candidateName}</h2>
+          <button onClick={onClose} className="text-gray-500">✕</button>
+        </div>
+        <div className="space-y-4 mb-4">
+          {comments.map((c, i) => (
+            <div key={i} className="bg-gray-50 rounded p-2 text-sm text-gray-700">
+              {c}
+            </div>
+          ))}
+        </div>
+        <MentionInput value={input} onChange={setInput} onSubmit={add} />
+      </div>
+      <div className="flex-1" onClick={onClose} />
+    </div>
+  );
+}

--- a/packages/web/src/components/job/InviteCollaboratorsModal.tsx
+++ b/packages/web/src/components/job/InviteCollaboratorsModal.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { canPlan } from '../../lib/permissions';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function InviteCollaboratorsModal({ onClose }: Props) {
+  const [emails, setEmails] = useState('');
+  const plan = 'free';
+  const currentCollabs = 2;
+  const limitReached = !canPlan('invite', plan as any, { collabCount: currentCollabs });
+
+  const invite = () => {
+    if (limitReached) return;
+    console.log('invite', emails.split(','));
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-4">Invite Collaborators</h2>
+        {limitReached && (
+          <p className="mb-4 text-sm text-red-600">
+            Invite limit reached for your plan.
+          </p>
+        )}
+        <textarea
+          value={emails}
+          onChange={(e) => setEmails(e.target.value)}
+          placeholder="Enter emails separated by commas"
+          className="w-full border rounded p-2 mb-4"
+          rows={3}
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded border border-gray-300 text-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={invite}
+            disabled={limitReached}
+            className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+          >
+            Invite
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/job/JobRequisitionLayout.tsx
+++ b/packages/web/src/components/job/JobRequisitionLayout.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faArrowLeft,
+  faShareAlt,
+  faRobot,
+  faEdit,
+  faArchive,
+  faCopy,
+} from '@fortawesome/free-solid-svg-icons';
+
+const tabs = ['overview', 'team', 'candidates', 'activity', 'pipeline'] as const;
+type Tab = typeof tabs[number];
+
+export default function JobRequisitionLayout() {
+  const [active, setActive] = useState<Tab>('overview');
+  const assignees = [
+    { id: '1', name: 'Alice', avatar: 'https://ui-avatars.com/api/?name=Alice' },
+    { id: '2', name: 'Bob', avatar: 'https://ui-avatars.com/api/?name=Bob' },
+  ];
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <header className="bg-white border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <button className="text-gray-500 hover:text-gray-700">
+              <FontAwesomeIcon icon={faArrowLeft} />
+            </button>
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">Job Title</h1>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="px-2.5 py-0.5 rounded-full bg-green-100 text-green-800 text-xs font-medium">
+                  open
+                </span>
+                {['Engineering', 'Remote', 'Senior'].map((t) => (
+                  <span key={t} className="text-sm text-gray-500">
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex -space-x-2 mr-2">
+              {assignees.map((a) => (
+                <img
+                  key={a.id}
+                  src={a.avatar}
+                  alt={a.name}
+                  className="w-8 h-8 rounded-full border-2 border-white"
+                />
+              ))}
+            </div>
+            <button className="p-2 text-gray-600 hover:text-gray-800" aria-label="Share">
+              <FontAwesomeIcon icon={faShareAlt} />
+            </button>
+            <button className="p-2 text-gray-600 hover:text-gray-800" aria-label="REX">
+              <FontAwesomeIcon icon={faRobot} />
+            </button>
+            <button className="p-2 text-gray-600 hover:text-gray-800" aria-label="Edit">
+              <FontAwesomeIcon icon={faEdit} />
+            </button>
+            <button className="p-2 text-gray-600 hover:text-gray-800" aria-label="Archive">
+              <FontAwesomeIcon icon={faArchive} />
+            </button>
+            <button className="p-2 text-gray-600 hover:text-gray-800" aria-label="Clone">
+              <FontAwesomeIcon icon={faCopy} />
+            </button>
+          </div>
+        </div>
+        <nav className="max-w-7xl mx-auto px-6 flex gap-6">
+          {tabs.map((t) => (
+            <button
+              key={t}
+              onClick={() => setActive(t)}
+              className={`py-4 px-1 text-sm font-medium border-b-2 -mb-px focus:outline-none ${
+                active === t
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </nav>
+      </header>
+      <main className="max-w-7xl mx-auto px-6 py-6">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/packages/web/src/components/job/MentionInput.tsx
+++ b/packages/web/src/components/job/MentionInput.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+}
+
+const MOCK_USERS = [
+  { id: '1', name: 'Alice' },
+  { id: '2', name: 'Bob' },
+  { id: '3', name: 'Charlie' },
+];
+
+export default function MentionInput({ value, onChange, onSubmit }: Props) {
+  const [suggestions, setSuggestions] = useState<typeof MOCK_USERS>([]);
+  const [index, setIndex] = useState(-1);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      if (!value.includes('@')) {
+        setSuggestions([]);
+        return;
+      }
+      const q = value.split('@').pop()?.toLowerCase() ?? '';
+      setSuggestions(
+        MOCK_USERS.filter((u) => u.name.toLowerCase().startsWith(q))
+      );
+    }, 200);
+  }, [value]);
+
+  const keyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setIndex((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (index >= 0 && suggestions[index]) {
+        const user = suggestions[index];
+        const replaced = value.replace(/@[^\s]*$/, '@' + user.name + ' ');
+        onChange(replaced);
+        setSuggestions([]);
+        setIndex(-1);
+      } else {
+        onSubmit();
+      }
+    }
+  };
+
+  return (
+    <div className="relative">
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={keyDown}
+        className="w-full border rounded p-2 focus:outline-none"
+        rows={3}
+      />
+      {suggestions.length > 0 && (
+        <ul className="absolute z-10 bg-white border rounded w-full mt-1 max-h-40 overflow-y-auto">
+          {suggestions.map((s, i) => (
+            <li
+              key={s.id}
+              className={`px-3 py-2 text-sm cursor-pointer ${
+                i === index ? 'bg-blue-600 text-white' : 'hover:bg-gray-100'
+              }`}
+              onMouseDown={() => {
+                const replaced = value.replace(/@[^\s]*$/, '@' + s.name + ' ');
+                onChange(replaced);
+                setSuggestions([]);
+                setIndex(-1);
+              }}
+            >
+              {s.name}
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-2 flex justify-end">
+        <button
+          onClick={onSubmit}
+          className="px-3 py-1 bg-blue-600 text-white rounded text-sm"
+        >
+          Post
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/job/tabs/ActivityTab.tsx
+++ b/packages/web/src/components/job/tabs/ActivityTab.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import FilterBar from '../../common/FilterBar';
+import ActivityFeed from '../ActivityFeed';
+
+const FILTERS = ['Comments', 'Stage Moves', 'Invites', 'Uploads', 'REX'];
+
+export default function ActivityTab() {
+  const [active, setActive] = useState<string[]>([]);
+
+  const toggle = (f: string) => {
+    setActive((prev) =>
+      prev.includes(f) ? prev.filter((p) => p !== f) : [...prev, f]
+    );
+  };
+
+  return (
+    <div>
+      <FilterBar filters={FILTERS} active={active} onToggle={toggle} />
+      <ActivityFeed />
+    </div>
+  );
+}

--- a/packages/web/src/components/job/tabs/CandidatesTab.tsx
+++ b/packages/web/src/components/job/tabs/CandidatesTab.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+const stages = ['Applied', 'Screened', 'Interview', 'Offer'];
+
+export default function CandidatesTab() {
+  const candidates = stages.reduce<Record<string, { id: string; name: string }[]>>(
+    (acc, stage) => {
+      acc[stage] = [
+        { id: stage + '1', name: stage + ' Candidate' },
+        { id: stage + '2', name: stage + ' Person' },
+      ];
+      return acc;
+    },
+    {}
+  );
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      {stages.map((stage) => (
+        <div
+          key={stage}
+          className="bg-white border border-gray-200 rounded-lg p-4 flex flex-col max-h-[70vh]"
+        >
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-medium text-gray-700">{stage}</h3>
+            <span className="text-xs bg-gray-100 px-2 py-0.5 rounded-full">
+              {candidates[stage].length}
+            </span>
+          </div>
+          <div className="space-y-3 overflow-y-auto">
+            {candidates[stage].map((c) => (
+              <div
+                key={c.id}
+                className="border rounded-lg p-3 flex items-center gap-3 hover:shadow"
+              >
+                <img
+                  src={`https://ui-avatars.com/api/?name=${c.name}`}
+                  className="w-8 h-8 rounded-full"
+                  alt={c.name}
+                />
+                <div>
+                  <p className="text-sm font-medium text-gray-900">{c.name}</p>
+                  <p className="text-xs text-gray-500">{stage}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/components/job/tabs/OverviewTab.tsx
+++ b/packages/web/src/components/job/tabs/OverviewTab.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import MentionInput from '../MentionInput';
+
+export default function OverviewTab() {
+  const [description, setDescription] = useState('Describe the role...');
+  const [notes, setNotes] = useState<string[]>([
+    'Initial note from Alice',
+  ]);
+  const [input, setInput] = useState('');
+
+  const addNote = () => {
+    if (!input.trim()) return;
+    setNotes([...notes, input.trim()]);
+    setInput('');
+    console.log('activity', {
+      type: 'comment_added',
+      metadata: { text: input.trim() },
+    });
+  };
+
+  const saveDescription = () => {
+    console.log('activity', {
+      type: 'updated_description',
+      metadata: { fields: ['description'] },
+    });
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="lg:col-span-2 space-y-6">
+        <section className="bg-white border border-gray-200 rounded-lg p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-gray-900">Role Description</h2>
+            <button
+              onClick={saveDescription}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              Save
+            </button>
+          </div>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full border rounded p-2 focus:outline-none"
+            rows={4}
+          />
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Success Profile</h2>
+          <div className="flex flex-wrap gap-2">
+            {['Collaboration', 'Initiative', 'Growth mindset'].map((trait) => (
+              <span
+                key={trait}
+                className="px-3 py-1 bg-gray-50 rounded text-sm text-gray-700"
+              >
+                {trait}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Internal Notes</h2>
+          <div className="space-y-4 max-h-64 overflow-y-auto">
+            {notes.map((n, i) => (
+              <div key={i} className="flex items-start gap-3">
+                <img
+                  src={`https://ui-avatars.com/api/?name=User${i}`}
+                  className="w-8 h-8 rounded-full"
+                  alt="avatar"
+                />
+                <div className="bg-gray-50 rounded-lg p-3 w-full">
+                  <p className="text-sm text-gray-700">{n}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4">
+            <MentionInput value={input} onChange={setInput} onSubmit={addNote} />
+          </div>
+        </section>
+      </div>
+
+      <aside className="space-y-6">
+        <section className="bg-white border border-gray-200 rounded-lg p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Job Details</h3>
+          <dl className="grid grid-cols-1 gap-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-500">Department</dt>
+              <dd className="text-gray-900">Engineering</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-500">Location</dt>
+              <dd className="text-gray-900">Remote</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-500">Level</dt>
+              <dd className="text-gray-900">Senior</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-lg p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Assigned Team</h3>
+          <div className="space-y-3">
+            {[
+              { id: '1', name: 'Alice', role: 'editor' },
+              { id: '2', name: 'Bob', role: 'commenter' },
+            ].map((m) => (
+              <div key={m.id} className="flex items-center gap-3">
+                <img
+                  src={`https://ui-avatars.com/api/?name=${m.name}`}
+                  className="w-10 h-10 rounded-full"
+                  alt={m.name}
+                />
+                <div>
+                  <p className="text-sm font-medium text-gray-900">{m.name}</p>
+                  <p className="text-sm text-gray-500 capitalize">{m.role}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </aside>
+    </div>
+  );
+}

--- a/packages/web/src/components/job/tabs/TeamTab.tsx
+++ b/packages/web/src/components/job/tabs/TeamTab.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import InviteCollaboratorsModal from '../InviteCollaboratorsModal';
+
+interface Collab {
+  id: string;
+  name: string;
+  role: 'viewer' | 'commenter' | 'editor';
+}
+
+export default function TeamTab() {
+  const [collabs, setCollabs] = useState<Collab[]>([
+    { id: '1', name: 'Alice', role: 'editor' },
+    { id: '2', name: 'Bob', role: 'commenter' },
+  ]);
+  const [showModal, setShowModal] = useState(false);
+
+  const updateRole = (id: string, role: Collab['role']) => {
+    setCollabs(collabs.map((c) => (c.id === id ? { ...c, role } : c)));
+  };
+
+  const remove = (id: string) => {
+    setCollabs(collabs.filter((c) => c.id !== id));
+  };
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Assigned Team</h2>
+        <button
+          onClick={() => setShowModal(true)}
+          className="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-1 text-sm"
+        >
+          Add Teammate
+        </button>
+      </div>
+      <div className="space-y-4">
+        {collabs.map((c) => (
+          <div key={c.id} className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <img
+                src={`https://ui-avatars.com/api/?name=${c.name}`}
+                className="w-10 h-10 rounded-full"
+                alt={c.name}
+              />
+              <span className="text-sm font-medium text-gray-900">{c.name}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <select
+                value={c.role}
+                onChange={(e) => updateRole(c.id, e.target.value as Collab['role'])}
+                className="border rounded p-1 text-sm"
+              >
+                <option value="viewer">Viewer</option>
+                <option value="commenter">Commenter</option>
+                <option value="editor">Editor</option>
+              </select>
+              <button
+                onClick={() => remove(c.id)}
+                className="text-gray-500 hover:text-red-600"
+                aria-label="Remove"
+              >
+                <span className="sr-only">Remove</span>🗑️
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {showModal && <InviteCollaboratorsModal onClose={() => setShowModal(false)} />}
+    </div>
+  );
+}

--- a/packages/web/src/lib/notify.ts
+++ b/packages/web/src/lib/notify.ts
@@ -1,0 +1,47 @@
+export type NotifyType = 'collaborator_added' | 'comment_added' | 'stage_moved' | 'file_uploaded';
+
+export const slackBlocks = (p: {
+  type: NotifyType;
+  job: { id: string; title: string };
+  actor: { id: string; name: string };
+  payload?: Record<string, unknown>;
+}) => {
+  const title = p.job.title ?? 'Job';
+  const who = p.actor.name ?? 'Someone';
+  const summary: Record<NotifyType, string> = {
+    collaborator_added: `${who} added a collaborator to *${title}*`,
+    comment_added: `${who} commented on *${title}*`,
+    stage_moved: `${who} moved a candidate stage in *${title}*`,
+    file_uploaded: `${who} uploaded a file to *${title}*`,
+  };
+  return [
+    { type: 'section', text: { type: 'mrkdwn', text: summary[p.type] } },
+    { type: 'context', elements: [{ type: 'mrkdwn', text: `Job ID: ${p.job.id}` }] },
+    ...(p.payload
+      ? [{ type: 'section', text: { type: 'mrkdwn', text: '```' + JSON.stringify(p.payload, null, 2) + '```' } }]
+      : []),
+  ];
+};
+
+export const sendgridMessage = (p: {
+  type: NotifyType;
+  job: { id: string; title: string };
+  actor: { id: string; name: string };
+  recipient: { email: string; name?: string };
+  payload?: Record<string, unknown>;
+}) => {
+  const subjMap: Record<NotifyType, string> = {
+    collaborator_added: `New collaborator · ${p.job.title}`,
+    comment_added: `New comment · ${p.job.title}`,
+    stage_moved: `Stage moved · ${p.job.title}`,
+    file_uploaded: `File uploaded · ${p.job.title}`,
+  };
+  const text = `${p.actor.name ?? 'Someone'} triggered ${p.type} on ${p.job.title}.\n\n` +
+    (p.payload ? JSON.stringify(p.payload, null, 2) : '');
+  return {
+    personalizations: [{ to: [{ email: p.recipient.email, name: p.recipient.name }] }],
+    from: { email: 'notifications@thehirepilot.com', name: 'HirePilot' },
+    subject: subjMap[p.type],
+    content: [{ type: 'text/plain', value: text }],
+  };
+};

--- a/packages/web/src/lib/permissions.test.ts
+++ b/packages/web/src/lib/permissions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { canPlan, canRole, isLocked } from './permissions';
+
+describe('permissions', () => {
+  it('respects plan limits', () => {
+    expect(canPlan('invite', 'pro', { collabCount: 1 })).toBe(true);
+    expect(canPlan('invite', 'pro', { collabCount: 2 })).toBe(false);
+    expect(canPlan('pipeline', 'free')).toBe(false);
+    expect(canPlan('edit', 'team')).toBe(true);
+  });
+
+  it('checks collaborator roles', () => {
+    expect(canRole('comment', 'viewer')).toBe(false);
+    expect(canRole('comment', 'commenter')).toBe(true);
+    expect(canRole('edit', 'commenter')).toBe(false);
+    expect(canRole('edit', 'editor')).toBe(true);
+  });
+
+  it('detects locked plans', () => {
+    expect(isLocked('free')).toBe(true);
+    expect(isLocked('starter')).toBe(true);
+    expect(isLocked('team')).toBe(false);
+  });
+});

--- a/packages/web/src/lib/permissions.ts
+++ b/packages/web/src/lib/permissions.ts
@@ -1,0 +1,24 @@
+export type Plan = 'free' | 'starter' | 'pro' | 'team';
+export type CollabRole = 'viewer' | 'commenter' | 'editor';
+export type Feature = 'invite' | 'comment' | 'edit' | 'pipeline' | 'activity';
+
+export function canPlan(feature: Feature, plan: Plan, ctx?: { collabCount?: number }): boolean {
+  if (plan === 'free' || plan === 'starter') {
+    return false;
+  }
+  if (plan === 'pro') {
+    if (feature === 'invite') {
+      return (ctx?.collabCount ?? 0) < 2;
+    }
+    return true;
+  }
+  return true;
+}
+
+export function canRole(action: 'comment' | 'edit', role: CollabRole): boolean {
+  if (action === 'comment') return role === 'commenter' || role === 'editor';
+  if (action === 'edit') return role === 'editor';
+  return false;
+}
+
+export const isLocked = (plan: Plan): boolean => plan === 'free' || plan === 'starter';

--- a/packages/web/src/pages/job/[id].tsx
+++ b/packages/web/src/pages/job/[id].tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import PublicNavbar from '../../components/PublicNavbar';
+import PremiumFeatureLockModal from '../../components/billing/PremiumFeatureLockModal';
+import { canPlan, canRole, Plan, CollabRole } from '../../lib/permissions';
+
+const tabs = ['overview', 'team', 'candidates', 'activity', 'pipeline'] as const;
+type Tab = typeof tabs[number];
+
+const featureLabels: Record<string, string> = {
+  invite: 'Inviting collaborators',
+  comment: 'Commenting',
+  pipeline: 'Pipeline',
+  activity: 'Activity',
+};
+
+export default function JobRequisitionPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [title, setTitle] = useState('Job Title');
+  const [status] = useState('draft');
+  const [dept] = useState('Engineering');
+  const [location] = useState('Remote');
+  const [level] = useState('Senior');
+  const [assignees] = useState([
+    { id: '1', name: 'Alice', avatar: 'https://ui-avatars.com/api/?name=Alice' },
+    { id: '2', name: 'Bob', avatar: 'https://ui-avatars.com/api/?name=Bob' },
+  ]);
+
+  const plan: Plan = 'free';
+  const role: CollabRole = 'viewer';
+  const [activeTab, setActiveTab] = useState<Tab>('overview');
+  const [lockedFeature, setLockedFeature] = useState<string | null>(null);
+  const collabCount = assignees.length;
+
+  const editable = canRole('edit', role);
+
+  const handleInvite = () => {
+    if (!canPlan('invite', plan, { collabCount })) {
+      setLockedFeature(featureLabels.invite);
+      return;
+    }
+    // stub invite action
+  };
+
+  const handleComment = () => {
+    if (!canPlan('comment', plan)) {
+      setLockedFeature(featureLabels.comment);
+      return;
+    }
+    // stub comment action
+  };
+
+  const handleTab = (tab: Tab) => {
+    if (tab === 'pipeline' && !canPlan('pipeline', plan)) {
+      setLockedFeature(featureLabels.pipeline);
+      return;
+    }
+    if (tab === 'activity' && !canPlan('activity', plan)) {
+      setLockedFeature(featureLabels.activity);
+      return;
+    }
+    setActiveTab(tab);
+    if (tab === 'pipeline') navigate(`/job/${id}/pipeline`);
+  };
+
+  return (
+    <div>
+      <PublicNavbar />
+      <div className="max-w-5xl mx-auto p-4">
+        <div className="flex items-start justify-between">
+          <div>
+            {editable ? (
+              <input
+                className="text-2xl font-semibold border-b focus:outline-none"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
+            ) : (
+              <h1 className="text-2xl font-semibold">{title}</h1>
+            )}
+            <div className="mt-2 flex items-center gap-2">
+              <span className="px-2 py-1 bg-gray-100 rounded text-sm capitalize">{status}</span>
+              {[dept, location, level].map((tag) => (
+                <span key={tag} className="px-2 py-1 bg-gray-100 rounded text-sm">
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div className="mt-2 flex -space-x-2">
+              {assignees.map((a) => (
+                <img
+                  key={a.id}
+                  src={a.avatar}
+                  alt={a.name}
+                  className="w-8 h-8 rounded-full border-2 border-white"
+                />
+              ))}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button className="btn" onClick={handleInvite}>
+              Share
+            </button>
+            <button className="btn" onClick={() => {}}>
+              REX
+            </button>
+            <button className="btn" onClick={() => {}} disabled={!editable}>
+              Edit
+            </button>
+            <button className="btn" onClick={() => {}}>
+              Archive
+            </button>
+            <button className="btn" onClick={() => {}}>
+              Clone
+            </button>
+          </div>
+        </div>
+        <div className="mt-6 border-b">
+          <nav className="flex gap-4">
+            {tabs.map((t) => (
+              <button
+                key={t}
+                className={`pb-2 ${activeTab === t ? 'border-b-2 border-blue-500' : ''}`}
+                onClick={() => handleTab(t)}
+              >
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </button>
+            ))}
+          </nav>
+        </div>
+        <div className="mt-4">
+          {activeTab === 'overview' && <div>Overview content</div>}
+          {activeTab === 'team' && (
+            <div>
+              Team content
+              <button className="ml-2 underline" onClick={handleInvite}>
+                Invite
+              </button>
+            </div>
+          )}
+          {activeTab === 'candidates' && (
+            <div>
+              Candidates content
+              <button className="ml-2 underline" onClick={handleComment}>
+                Comment
+              </button>
+            </div>
+          )}
+          {activeTab === 'activity' && <div>Activity feed</div>}
+          {activeTab === 'pipeline' && <div>Pipeline content</div>}
+        </div>
+      </div>
+      {lockedFeature && (
+        <PremiumFeatureLockModal
+          featureName={lockedFeature}
+          onClose={() => setLockedFeature(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/job/[id]/pipeline.tsx
+++ b/packages/web/src/pages/job/[id]/pipeline.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
+
+interface Candidate {
+  id: string;
+  name: string;
+  stage: string;
+}
+
+const stages = ['sourced', 'interview', 'offer'];
+
+export default function JobPipelinePage() {
+  const { id } = useParams<{ id: string }>();
+  const [candidates, setCandidates] = useState<Candidate[]>([
+    { id: '1', name: 'Alice', stage: 'sourced' },
+    { id: '2', name: 'Bob', stage: 'interview' },
+  ]);
+
+  const onDragEnd = async (result: DropResult) => {
+    if (!result.destination) return;
+    const candidateId = result.draggableId;
+    const newStage = result.destination.droppableId;
+    setCandidates((prev) =>
+      prev.map((c) => (c.id === candidateId ? { ...c, stage: newStage } : c))
+    );
+    await fetch(`/api/jobs/${id}/candidates/${candidateId}/stage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stage: newStage }),
+    });
+    await fetch('/notify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'stage_moved',
+        job_id: id,
+        actor_id: 'actor',
+        payload: { candidate_id: candidateId, stage: newStage },
+      }),
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-semibold mb-4">Pipeline</h1>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <div className="flex gap-4">
+          {stages.map((stage) => (
+            <Droppable droppableId={stage} key={stage}>
+              {(provided) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  className="bg-gray-100 rounded p-4 w-64 min-h-[200px]"
+                >
+                  <h2 className="font-medium mb-2 capitalize">{stage}</h2>
+                  {candidates
+                    .filter((c) => c.stage === stage)
+                    .map((c, index) => (
+                      <Draggable key={c.id} draggableId={c.id} index={index}>
+                        {(prov) => (
+                          <div
+                            ref={prov.innerRef}
+                            {...prov.draggableProps}
+                            {...prov.dragHandleProps}
+                            className="bg-white p-2 rounded mb-2 shadow"
+                          >
+                            {c.name}
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          ))}
+        </div>
+      </DragDropContext>
+    </div>
+  );
+}

--- a/supabase/functions/_shared/server.ts
+++ b/supabase/functions/_shared/server.ts
@@ -1,0 +1,12 @@
+export type Handler = (req: Request) => Response | Promise<Response>;
+
+export function server(handler: Handler) {
+  Deno.serve(async (req: Request) => {
+    try {
+      return await handler(req);
+    } catch (err) {
+      console.error(err);
+      return new Response('Internal Server Error', { status: 500 });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add job requisition layout with tabbed navigation and action icons
- scaffold overview, team, candidates, and activity tabs with placeholder data
- introduce mention input, invite modal, activity feed, and candidate comment drawer

## Testing
- ⚠️ `npx vitest run packages/web/src/lib/permissions.test.ts` (failed: 403 Forbidden - GET https://registry.npmjs.org/vitest)

## Checklist
- [ ] Components render styled like HTML spec
- [ ] MentionInput works with autocomplete
- [ ] InviteCollaboratorsModal enforces plan limits
- [ ] OverviewTab saves insert activity events

------
https://chatgpt.com/codex/tasks/task_e_68c1e07444d88326be90fe72e333c732